### PR TITLE
기본적인 docker 컨테이너 생성 뼈대 제작

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+dev-up:
+	docker compose -f docker-compose.dev.yml up --build -d
+
+dev-down:
+	docker compose -f docker-compose.dev.yml down --rmi all -v --remove-orphans

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,0 +1,19 @@
+FROM python:3.9.6
+
+# 작업 디렉토리를 설정합니다.
+WORKDIR /code
+
+# 필요한 패키지들을 설치합니다.
+RUN apt-get update && apt-get install -y \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# 프로젝트 파일들을 컨테이너에 복사합니다.
+COPY . /code/
+
+# requirements.txt 파일을 설치합니다.
+RUN pip install --upgrade pip
+RUN pip install -r requirements.txt
+
+# Django 애플리케이션을 실행하는 명령어를 설정합니다.
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -37,7 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'authenticationapp',
+    # 'authenticationapp',
 ]
 
 MIDDLEWARE = [

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,12 @@
+services:
+  backend:
+    build:
+      context: ./backend/
+      dockerfile: Dockerfile.dev
+    volumes:
+      - ./backend:/code
+    ports:
+      - "8000:8000"
+    environment:
+      - DEBUG=1
+      - DJANGO_ALLOWED_HOSTS=localhost 127.0.0.1 [::1]


### PR DESCRIPTION
## Makefile 작성
* 사용법
    - make dev-up 
    - make dev-down
    
port는 8000으로 해뒀습니다.

setting.py 내에 'authenticationapp' 부분이 에러가 발생해서 주석처리 해뒀습니다.

배포 환경에서의 도커(ex, dockerfile.prop)는 나중에 추가하면 될 거 같습니다.